### PR TITLE
Add suggested additional settings link

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,10 @@
 				"command": "cline.openInNewTab",
 				"title": "Open In New Tab",
 				"category": "Cline"
+			},
+			{
+				"command": "cline.openClineSettings",
+				"title": "Open Cline Settings"
 			}
 		],
 		"menus": {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -514,6 +514,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						}
 						break
 					}
+					case "openSettings": {
+						await vscode.commands.executeCommand("cline.openClineSettings")
+						break
+					}
 					// Add more switch case statements here as more webview message commands
 					// are created within the webview context (i.e. inside media/main.js)
 				}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,12 @@ export function activate(context: vscode.ExtensionContext) {
 		}),
 	)
 
+	context.subscriptions.push(
+		vscode.commands.registerCommand("cline.openClineSettings", () => {
+			vscode.commands.executeCommand("workbench.action.openSettings", "@ext:saoudrizwan.claude-dev")
+		}),
+	)
+
 	const openClineInNewTab = async () => {
 		outputChannel.appendLine("Opening Cline in new tab")
 		// (this example uses webviewProvider activation event which is necessary to deserialize cached webview, but since we use retainContextWhenHidden, we don't need to use that event)

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -26,6 +26,7 @@ export interface WebviewMessage {
 		| "openMcpSettings"
 		| "restartMcpServer"
 		| "autoApprovalSettings"
+		| "openSettings"
 	text?: string
 	askResponse?: ClineAskResponse
 	apiConfiguration?: ApiConfiguration

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -121,7 +121,11 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 						</p>
 					</>
 				)}
-
+				<div style={{ margin: "10px 0 10px 0" }}>
+					<VSCodeLink onClick={() => vscode.postMessage({ type: "openSettings" })}>
+						Additional settings
+					</VSCodeLink>
+				</div>
 				<div
 					style={{
 						textAlign: "center",


### PR DESCRIPTION
### Description

Add an "Additional settings" command link to expose Cline settings.

There isn't a way (that I can find) to link directly to vscode settings, but this gets there via a "command" to open the extension setting.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="926" alt="image" src="https://github.com/user-attachments/assets/3f4c046c-5d08-4e8b-adab-eb00eaf272b1" />

### Additional Notes

Under discussion
